### PR TITLE
chore: update nghttp2 to remove the CVE and use official docker image for postgresql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/do
 RUN chmod +x /usr/local/bin/install-php-extensions
 
 # persistent / runtime deps
-RUN apk add --no-cache \
+RUN apk update && apk upgrade && apk add --no-cache \
 		acl \
 		fcgi \
 		file \

--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -26,10 +26,10 @@ appVersion: 0.0.1
 
 dependencies:
   # bitnami chart are using the workaround from https://github.com/bitnami/charts/issues/10539
-  - name: postgresql
-    version: ~11.9.13
-    repository: https://charts.bitnami.com/bitnami/
-    condition: postgresql.enabled
+  - name: postgres
+    version: 1.6.3
+    repository: https://groundhog2k.github.io/helm-charts/
+    condition: postgres.enabled
   - name: external-dns
     version: ~5.4.15
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami

--- a/helm/chart/templates/secrets.yaml
+++ b/helm/chart/templates/secrets.yaml
@@ -6,10 +6,10 @@ metadata:
     {{- include "plateforme-ebs.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if .Values.postgresql.enabled }}
-  database-url: {{ printf "pgsql://%s:%s@%s-postgresql/%s?serverVersion=14&charset=utf8" .Values.postgresql.global.postgresql.auth.username .Values.postgresql.global.postgresql.auth.password .Release.Name .Values.postgresql.global.postgresql.auth.database | b64enc | quote }}
+  {{- if .Values.postgres.enabled }}
+  database-url: {{ printf "pgsql://%s:%s@%s-postgres/%s?serverVersion=14&charset=utf8" .Values.postgres.userDatabase.user.value .Values.postgres.userDatabase.password.value .Release.Name .Values.postgres.userDatabase.name.value | b64enc | quote }}
   {{- else }}
-  database-url: {{ .Values.postgresql.url | b64enc | quote }}
+  database-url: {{ .Values.postgres.url | b64enc | quote }}
   {{- end }}
   php-app-secret: {{ .Values.php.appSecret | default (randAlphaNum 40) | b64enc | quote }}
   php-jwt-passphrase: {{ .Values.php.jwt.passphrase | b64enc | quote }}

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -69,34 +69,32 @@ mercure:
   jwtSecret: "!ChangeThisMercureHubJWTSecretKey!"
   extraDirectives: cors_origins http://ghcr.io https://ghcr.io
 
-# Full configuration: https://github.com/bitnami/charts/tree/master/bitnami/postgresql
-postgresql:
+# Full configuration: https://github.com/groundhog2k/helm-charts/tree/master/charts/postgres
+postgres:
   enabled: true
   # If bringing your own PostgreSQL, the full uri to use
   # url: postgresql://plateforme-ebs:!ChangeMe!@database:5432/api?serverVersion=13&charset=utf8
-  global:
-    postgresql:
-      auth:
-        username: "example"
-        password: "!ChangeMe!"
-        database: "api"
-        postgresPassword: "!ChangeMe!"
-  # Persistent Volume Storage configuration.
-  # ref: https://kubernetes.io/docs/user-guide/persistent-volumes
-  pullPolicy: IfNotPresent
   image:
     registry: docker.io
     repository: postgres
-    tag: 14
-  primary:
-    persistence:
-      enabled: true
-      storageClass: standard
-      size: 1Gi
-    resources:
-      requests:
-        memory: 50Mi
-        cpu: 1m
+    tag: "14"
+  settings:
+    superuserPassword:
+      value: "!ChangeMe!"
+  userDatabase:
+    name:
+      value: "api"
+    user:
+      value: "example"
+    password:
+      value: "!ChangeMe!"
+  storage:
+    className: standard
+    requestedSize: 1Gi
+  resources:
+    requests:
+      memory: 50Mi
+      cpu: 1m
 
 payum:
   # @see https://my.mollie.com/dashboard/org_XXXXXXXX/developers/api-keys

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -86,7 +86,7 @@ postgresql:
   pullPolicy: IfNotPresent
   image:
     registry: docker.io
-    repository: bitnamilegacy/postgresql
+    repository: postgres
     tag: 14
   primary:
     persistence:


### PR DESCRIPTION
# Description

A new CVE appeared on Trivy about nghttp2 and I fixed it by updating nghttp2 on dockerfile.

Kevin asked me to use official docker repo instead of bitnami one for postgresql to keep getting update

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)