### PR TITLE
chore: ignore major version and add docker to dependabot analysis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
       symfony:
         patterns:
           - "symfony/*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
 
   - package-ecosystem: "npm"
@@ -25,6 +29,10 @@ updates:
     schedule:
         interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
 
   - package-ecosystem: "github-actions"
@@ -34,3 +42,20 @@ updates:
     schedule:
         interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    commit-message:
+        prefix: "chore"
+    schedule:
+        interval: "weekly"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
# Description

Dependabot maintenant ne traite que les versions patch et mineurs (pas les versions majeurs). Et il traite aussi les images Docker qu'on utilise dans Dockerfile (pour par exemple avoir Caddy à jour)

## Type of change

- [x] Improvment of an existing feature (minor tweak)

# How Has This Been Tested?

J'ai vérifier avec les documentations de Dependabot par Github.
  
