### PR TITLE
chore(security): ignore CVE-2026-39822 (stdlib Go, binaire caddy)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -8,3 +8,7 @@ CVE-2026-32280
 CVE-2026-32281
 CVE-2026-32283
 CVE-2026-33810
+# CVE-2026-39822 : vuln HIGH dans la stdlib Go du binaire caddy.
+# Fixée côté Go (1.26.5+), en attente d'une release caddy patchée.
+# À retirer dès qu'une image caddy à jour est dispo. (juillet 2026)
+CVE-2026-39822


### PR DESCRIPTION
Ajoute CVE-2026-39822 au .trivyignore. Cette vuln HIGH est dans la stdlib Go du binaire caddy (usr/bin/caddy), révélée lors du premier run complet du CD sur staging. Elle est fixée côté Go (1.26.5+) mais nécessite une release caddy recompilée avec ce Go. En attendant cette release upstream, on ignore l'alerte Trivy pour débloquer le déploiement (l'alerte ne bloquait que le CD, pas la CI). À retirer dès qu'une image caddy patchée est disponible.