### PR TITLE
fix: use attribute route loader type instead of deprecated annotation

### DIFF
--- a/config/routes/annotations.yaml
+++ b/config/routes/annotations.yaml
@@ -1,6 +1,6 @@
 controllers:
     resource: '../../src/Controller/'
-    type: annotation
+    type: attribute
     # the prefix is only used when i18n are not explicitly defined
     # allowed prefixes are defined by the "kernel.enabled_locales" parameter
     # @see config/packages/framework.yaml
@@ -9,4 +9,4 @@ controllers:
 # No prefix for the root route :) it handles "/" and redirects
 root:
     resource: '../../src/Controller/AppController.php'
-    type: annotation
+    type: attribute


### PR DESCRIPTION
## Summary
- `config/routes/annotations.yaml` used the `annotation` route loader type, deprecated since Symfony route loading moved to PHP 8 attributes.
- Controllers already use `#[Route(...)]` attributes, not annotations, so this switches both route resources to `type: attribute`.

## Test plan
- [ ] `bin/console debug:router` still lists all routes correctly
- [ ] Site loads and navigation works locally